### PR TITLE
Modification of command line options due to specification change of tflite2tensorflow

### DIFF
--- a/models/convert_models.sh
+++ b/models/convert_models.sh
@@ -10,31 +10,31 @@ tflite2tensorflow \
   --model_output_path palm_detection \
   --flatc_path ../../flatc \
   --schema_path ../../schema.fbs \
-  --output_pb True \
-  --optimizing_for_openvino_and_myriad True
+  --output_pb \
+  --optimizing_for_openvino_and_myriad
 # Generate Openvino "non normalized input" models: the normalization has to be mode explictly in the code
 #tflite2tensorflow \
 #  --model_path palm_detection.tflite \
 #  --model_output_path palm_detection \
 #  --flatc_path ../../flatc \
 #  --schema_path ../../schema.fbs \
-#  --output_openvino_and_myriad True 
-# Generate Openvino "normalized input" models 
+#  --output_openvino_and_myriad
+# Generate Openvino "normalized input" models
 /opt/intel/openvino_2021/deployment_tools/model_optimizer/mo_tf.py --input_model palm_detection/model_float32.pb --model_name palm_detection_${FP} --data_type ${FP} --mean_values "[127.5, 127.5, 127.5]" --scale_values "[127.5, 127.5, 127.5]" --reverse_input_channels
 
 # Hand landmark model
 tflite2tensorflow \
   --model_path hand_landmark.tflite \
-  --model_output_path hand_landmark\
+  --model_output_path hand_landmark \
   --flatc_path ../../flatc \
   --schema_path ../../schema.fbs \
-  --output_pb True
+  --output_pb
 # Generate Openvino "non normalized input" models: the normalization has to be mode explictly in the code
 # tflite2tensorflow \
 #   --model_path hand_landmark.tflite \
 #   --model_output_path hand_landmark \
 #   --flatc_path ../../flatc \
 #   --schema_path ../../schema.fbs \
-#   --output_openvino_and_myriad True
-# Generate Openvino "normalized input" models 
+#   --output_openvino_and_myriad
+# Generate Openvino "normalized input" models
 /opt/intel/openvino_2021/deployment_tools/model_optimizer/mo_tf.py --input_model hand_landmark/model_float32.pb --model_name hand_landmark_${FP} --data_type ${FP} --scale_values "[255.0, 255.0, 255.0]" --reverse_input_channels


### PR DESCRIPTION
Changed command line options to flag format.

FIx. https://github.com/PINTO0309/tflite2tensorflow/issues/7

From.
```
$ tflite2tensorflow \
  --model_path palm_detection.tflite \
  --flatc_path ../flatc \
  --schema_path ../schema.fbs \
  --output_pb True \
  --optimizing_for_openvino_and_myriad True
```
To.
```
$ tflite2tensorflow \
  --model_path palm_detection.tflite \
  --flatc_path ../flatc \
  --schema_path ../schema.fbs \
  --output_pb \
  --optimizing_for_openvino_and_myriad
```